### PR TITLE
Add space on focus option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+1.1.10
+- Added option to include a space at the end of search query when focusing the search box
+
 1.1.9
 - Don't wrap when arrow is prepended to search results
 - Bug Fix: Display marker when first result is automatically selected

--- a/js/options.js
+++ b/js/options.js
@@ -19,6 +19,7 @@
     document.getElementById('activateSearch').checked = extOptions.activateSearch;
     document.getElementById('autoselectFirst').checked = extOptions.autoselectFirst;
     document.getElementById('selectTextInSearchbox').checked = extOptions.selectTextInSearchbox;
+    document.getElementById('addSpaceOnFocus').checked = extOptions.addSpaceOnFocus;
   }
 
   function saveOptions() {
@@ -30,6 +31,7 @@
     extOptions.activateSearch = document.getElementById('activateSearch').checked === true;
     extOptions.autoselectFirst = document.getElementById('autoselectFirst').checked === true;
     extOptions.selectTextInSearchbox = document.getElementById('selectTextInSearchbox').checked === true;
+    extOptions.addSpaceOnFocus = document.getElementById('addSpaceOnFocus').checked === true;
     persistOptions();
   }
 

--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -12,7 +12,7 @@
 
   // Load options
   shortcuts.loadOptions(function(options) {
-    
+
     // Styling is present
     if (options.styleSelectedSimple || options.styleSelectedFancy) {
       document.body.className += " useHighlight";
@@ -57,7 +57,10 @@
       }
       else if (shouldActivateSearch) {
         // Otherwise, force caret to end of text and focus the search box
-        searchbox.value = searchbox.value + " ";
+        searchbox.selectionStart = searchbox.selectionEnd = searchbox.value.length;
+        if (options.addSpaceOnFocus) {
+          searchbox.value += " ";
+        }
         searchbox.focus();
       }
       else if (shouldActivateSearchAndHighlightText) {
@@ -71,7 +74,10 @@
       e = e || window.event;
 
       if (!shortcuts.isInputActive() && !shortcuts.hasModifierKey(e) && options.navigateWithJK && e.keyCode == KEYS.SLASH) {
-        searchbox.value = searchbox.value + " ";
+        searchbox.selectionStart = searchbox.selectionEnd = searchbox.value.length;
+        if (options.addSpaceOnFocus) {
+          searchbox.value += " ";
+        }
         searchbox.focus();
       }
     });

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,7 +24,10 @@ var shortcuts = {
     navigateWithJK: false,
 
     // Esc = select all text in searchbox
-    selectTextInSearchbox: false
+    selectTextInSearchbox: false,
+
+    // Add space on focus
+    addSpaceOnFocus: true
   },
 
   saveOptions: function(options, callback) {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "minimum_chrome_version": "28",
   "name": "Google Search Keyboard Shortcuts",
   "description": "Adds keyboard shortcuts/hotkeys back to Google search results",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "icons": {
     "16": "img/icon16.png",
     "32": "img/icon32.png",

--- a/options.html
+++ b/options.html
@@ -97,6 +97,7 @@
     <div><input type="checkbox" id="styleSelectedFancy"><label for="styleSelectedFancy">Add additional styling to the selected search result</label></div>
     <div><input type="checkbox" id="activateSearch"><label for="activateSearch">Focus the search box when any key is pressed</label></div>
     <div><input type="checkbox" id="autoselectFirst"><label for="autoselectFirst">Automatically select the first search result <em>(experimental)</em></label></div>
+    <div><input type="checkbox" id="addSpaceOnFocus"><label for="addSpaceOnFocus">Add a space when focusing the search box</label></div>
   </div>
   <br /><br />
   <div id="actionContainer">


### PR DESCRIPTION
When focusing the search box my intuition is that I would just have the cursor at the end of the search query that I just made but this isn't what happens, a space is added.

This is probably a personal preference thing so I wanted to include this as an option.

The repository didn't have any `CONTRIBUTING.md` guidelines so I just winged it and also went ahead and also added to the change log and version on the `manifest.json`.