### PR TITLE
allow getVisibleResults to work with AB tested UI variations

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -40,7 +40,7 @@ var shortcuts = {
   },
 
   getVisibleResults: function() {
-    var allResults = document.querySelectorAll('h3 a, #search .r > a:first-of-type, #foot a'),
+    var allResults = document.querySelectorAll('#search .rc > * > a:first-of-type, #foot a'),
         visibleResults = [];
 
     for (var i = 0; i < allResults.length; i++) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -40,7 +40,7 @@ var shortcuts = {
   },
 
   getVisibleResults: function() {
-    var allResults = document.querySelectorAll('#search .rc > * > a:first-of-type, #foot a'),
+    var allResults = document.querySelectorAll('h3 a, #search .rc > * > a:first-of-type, #foot a'),
         visibleResults = [];
 
     for (var i = 0; i < allResults.length; i++) {


### PR DESCRIPTION
Google's potential A/B testing of an updated search layout affected the document.querySelectorAll call within `getVisibleResults`.  While logged in to my Google account it only returns 10 elements for a query - all the bottom links to go to pages 2, 3, 4, ..., 10, and the Next button. All of the first page's rows were missing because the `a` tag's parent `div` with class name `r` changed (for me at least while logged in) to `yuRUbf`:

![image](https://user-images.githubusercontent.com/967811/93655646-d938c680-f9f2-11ea-86e3-1feada363a9f.png)

I initially got it to work in the Chrome Dev Tools by changing the call to:
```
document.querySelectorAll('h3 a, #search .r > a:first-of-type, #search .yuRUbf > a:first-of-type, #foot a')
```

However, that `yuRUbf` string may very well be a specific flavor of their A/B test and useless for others with a different variant. To make it disregard that intermediary div,  this 'match all descendants' selector worked:
```
document.querySelectorAll('#search .rc > * > a:first-of-type')
```

Also, I removed the initial `h3 a` part of the selector after testing it in both my logged-in Chrome and in Incognito - in both windows, that selector doesn't return anything.