### PR TITLE
docs(manifest): add `homepage_url`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
     "128": "img/icon128.png"
   },
   "author": "Jacob Chafik <jacobthedeveloper@gmail.com>",
+  "homepage_url": "https://github.com/jchafik/google-search-shortcuts",
   "options_ui": {
       "page": "options.html",
       "chrome_style": true


### PR DESCRIPTION
Google seems to have changed the selectors again, effectively breaking this addon for me. I wanted to submit a patch, but had trouble finding this repository.

This adds the project's GitHub repository URL as the `homepage_url` to the `manifest.json`, so that it is displayed in the Firefox / Chrome extension store listing. This makes it easier for users to find the source code and contribute fixes or features.

`homepage_url` is universally understood by Firefox, as well as the Chrome Extensions Manifest V3 & V2, which is what's currently used by this project.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url
https://developer.chrome.com/docs/extensions/mv3/manifest/
https://developer.chrome.com/docs/extensions/mv2/manifest/