### PR TITLE
fix: update `visibleResultsQuerySelector`

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -32,7 +32,34 @@ var shortcuts = {
   inputElementIds: ['cwtltblr' /* Google Calculator Widget */],
   inputElementTypes: ['text', 'number', 'textarea'],
 
-  visibleResultsQuerySelector: 'h3 a, #search a[data-ved][ping]',
+  // Finds all currently visible search result links.
+  // Unfortunately Google does not clearly mark search result links with a
+  // unique selector, so this selector is a brittle heuristic that may break any
+  // time Google changes the DOM structure / selectors, requiring a patch update
+  // of the addon to be pushed.
+  // Perspectively it may be beneficial to make this selector (or all of them)
+  // user-configurable, to enable users to temporarily fix it themselves, until
+  // a new patch update is out. We may also want to investigate a different
+  // approach, that e.g. does not only rely on a query selector, but includes
+  // additional heuristics, to improve the resiliency.
+  visibleResultsQuerySelector:
+    // Select all links in the main search results container, including
+    // non-search-result noise, like web cache, feedback, and further UI.
+    '#search a' +
+    // This selection is further refined with these filters:
+    // All actual search results have a `data-ved` attribute, but not all links
+    // with that attribute are search results.
+    '[data-ved]' +
+    // Some of them are interactive UI elements, like web cache, feedback, etc.
+    // They can be identified by the lack of a real target `href`.
+    ':not([href="#"])' +
+    // Google started inlining related questions and their search results as an
+    // accordion-type UI in an optional "People also ask" section. All accordion
+    // items are collapsed by default and marked as `aria-hidden` in that state.
+    // This filter excludes links that are invisible, as they are nested in a
+    // hidden ancestor element.
+    ':not([aria-hidden="true"] a)',
+
   resultContainerQuerySelector: 'div.gs_r, div.g, li, td',
   navigationContainerQuerySelector: 'div[role="navigation"] table',
   navigationLinksAndSuggestedSearchesQuerySelector: 'div[role="navigation"] table a, #botstuff a',


### PR DESCRIPTION
This PR changes the `visibleResultsQuerySelector` selector...
- from `h3 a, #search a[data-ved][ping]`
- to`#search a[data-ved]:not([href="#"]):not([aria-hidden="true"] a)`

...and explains the rationale as code comments.

I intentionally dropped `h3 a`, which only appears to have selected [sub-links of top results](https://user-images.githubusercontent.com/834636/124595153-f5fa9980-de60-11eb-91f1-0f74526e2f14.png), as these are already covered by the new selector.

I saw that you pushed edb7b18978dc9fb5654309cd1d547471ed80fb8a just a few days ago, which added `[ping]` to the selector. At least for me, this is not working, as the search result links do not include `[ping]`. This is what a search result looks like for me:

```html
<div class="g">
  <div data-hveid="CAMQAA" data-ved="2ahUKEwi80bWzo87xAhXghv0HHYMLBXgQFSgAMAF6BAgDEAA">
    <div class="tF2Cxc">
      <div class="yuRUbf">
        <a href="https://css-tricks.com/almanac/selectors/n/not/" data-ved="2ahUKEwi80bWzo87xAhXghv0HHYMLBXgQFjABegQIAxAD" onmousedown="return rwt(this,'','','','','AOvVaw3vAvcsIdyNAh3JRezcIT19','','2ahUKEwi80bWzo87xAhXghv0HHYMLBXgQFjABegQIAxAD','','',event)">
          <!-- Page title -->
        </a>
        <div class="B6fmyf">
          <div class="TbwUpd">
            <!-- Breadcrumbs -->
          </div>
          <div class="eFM0qc">
            <!-- Result options -->
          </div>
        </div>
        <!-- ... -->
      </div>
    </div>
  </div>
</div>
```

I've only tested this via the DevTools and did not actually compile the addon yet. Let me know, if you'd like me to change anything. Thanks for the great addon! ❤️ 