### PR TITLE
allow extension to focus search box on pages that don't use a textarea tag

### DIFF
--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -18,7 +18,7 @@
   };
 
   const addNavigationListener = (options) => {
-    const searchBox = document.querySelector('form[role="search"] textarea:nth-of-type(1)');
+    const searchBox = document.querySelector('form[role="search"] [name="q"]');
 
     window.addEventListener('keydown', (event) => {
       const keyPressed = event.keyCode;


### PR DESCRIPTION
Several of the search types (images, e.g.) don't use a `<textarea>` for the search input.  They use `<input type="text">`.  The extension doesn't let you focus the search box for those types.

Instead of selecting based on the tab, if it uses `name="q"`, which they all seem to share, it works.