### PR TITLE
Add keybindings to All, Image, Video and Maps search

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -20,6 +20,7 @@
     document.getElementById('autoselectFirst').checked = extOptions.autoselectFirst;
     document.getElementById('selectTextInSearchbox').checked = extOptions.selectTextInSearchbox;
     document.getElementById('addSpaceOnFocus').checked = extOptions.addSpaceOnFocus;
+    document.getElementById('enableGoogleShortcuts').checked = extOptions.enableGoogleShortcuts;
   }
 
   function saveOptions() {
@@ -32,6 +33,7 @@
     extOptions.autoselectFirst = document.getElementById('autoselectFirst').checked === true;
     extOptions.selectTextInSearchbox = document.getElementById('selectTextInSearchbox').checked === true;
     extOptions.addSpaceOnFocus = document.getElementById('addSpaceOnFocus').checked === true;
+    extOptions.enableGoogleShortcuts = document.getElementById('enableGoogleShortcuts').checked === true;
     persistOptions();
   }
 

--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -39,21 +39,25 @@
     window.addEventListener('keydown', (event) => {
       const keyPressed = event.keyCode;
 
-      if (keyPressed === KEYS.A) {    // A for All
-        navigateToTab('a[href^="/search"][href*="q="]:not([href*="tbm="]):not([href*="udm="])');
-        return
-      } else if (keyPressed === KEYS.I) {    // I for images
-        navigateToTab('a[href*="tbm=isch"], a[href*="udm=2&"], a[href$="udm=2"]')
-        return
-      } else if (keyPressed === KEYS.V) {    // V for videos
-        navigateToTab('a[href*="tbm=vid"], a[href*="udm=7&"], a[href$="udm=7"]')
-        return
-      } else if (keyPressed === KEYS.M) {    // M for maps
-        navigateToMaps()
-        return
+      const isInput = shortcuts.isInputActive();
+
+      if (options.enableGoogleShortcuts && !isInput && !(event.altKey || event.metaKey || event.ctrlKey)) {
+        if (keyPressed === KEYS.A) {    // A for All
+          navigateToTab('a[href^="/search"][href*="q="]:not([href*="tbm="]):not([href*="udm="])');
+          return
+        } else if (keyPressed === KEYS.I) {    // I for images
+          navigateToTab('a[href*="tbm=isch"], a[href*="udm=2&"], a[href$="udm=2"]')
+          return
+        } else if (keyPressed === KEYS.V) {    // V for videos
+          navigateToTab('a[href*="tbm=vid"], a[href*="udm=7&"], a[href$="udm=7"]')
+          return
+        } else if (keyPressed === KEYS.M) {    // M for maps
+          navigateToMaps()
+          return
+        }
       }
 
-      const isInputOrModifierActive = shortcuts.isInputActive() || shortcuts.hasModifierKey(event),
+      const isInputOrModifierActive = isInput || shortcuts.hasModifierKey(event),
 
         // From https://stackoverflow.com/questions/12467240/determine-if-javascript-e-keycode-is-a-printable-non-control-character
         isPrintable = (keyPressed >= 48 && keyPressed <= 57) || // number keys

--- a/js/shortcuts.js
+++ b/js/shortcuts.js
@@ -8,7 +8,7 @@
   }
 
   // Globals
-  const KEYS = {UP: 38, DOWN: 40, TAB: 9, J: 74, K: 75, SLASH: 191, ESC: 27};
+  const KEYS = {UP: 38, DOWN: 40, TAB: 9, A: 65, I: 73, J: 74, K: 75, M: 77, V: 86, SLASH: 191, ESC: 27};
 
   const addHighlightStyles = (options) => {
     const body = document.body;
@@ -20,8 +20,39 @@
   const addNavigationListener = (options) => {
     const searchBox = document.querySelector('form[role="search"] textarea:nth-of-type(1)');
 
+    const navigateToTab = (tabSelector) => {
+      const tabLink = document.querySelector(tabSelector);
+      if (tabLink) tabLink.click();
+    };
+
+    const navigateToMaps = () => {
+      const searchInput = document.querySelector('input[name="q"]');
+
+      if (searchInput) {
+        const searchQuery = encodeURIComponent(searchInput.value);
+
+        const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${searchQuery}`;
+        window.location.href = mapsUrl;
+      }
+    }
+
     window.addEventListener('keydown', (event) => {
       const keyPressed = event.keyCode;
+
+      if (keyPressed === KEYS.A) {    // A for All
+        navigateToTab('a[href^="/search"][href*="q="]:not([href*="tbm="]):not([href*="udm="])');
+        return
+      } else if (keyPressed === KEYS.I) {    // I for images
+        navigateToTab('a[href*="tbm=isch"], a[href*="udm=2&"], a[href$="udm=2"]')
+        return
+      } else if (keyPressed === KEYS.V) {    // V for videos
+        navigateToTab('a[href*="tbm=vid"], a[href*="udm=7&"], a[href$="udm=7"]')
+        return
+      } else if (keyPressed === KEYS.M) {    // M for maps
+        navigateToMaps()
+        return
+      }
+
       const isInputOrModifierActive = shortcuts.isInputActive() || shortcuts.hasModifierKey(event),
 
         // From https://stackoverflow.com/questions/12467240/determine-if-javascript-e-keycode-is-a-printable-non-control-character

--- a/js/utils.js
+++ b/js/utils.js
@@ -27,7 +27,10 @@ const shortcuts = {
     selectTextInSearchbox: false,
 
     // Add space on focus
-    addSpaceOnFocus: true
+    addSpaceOnFocus: true,
+
+    // Enable Google special bindings
+    enableGoogleShortcuts: false
   },
 
   focusIndex: -1,

--- a/options.html
+++ b/options.html
@@ -98,6 +98,7 @@
     <div><input type="checkbox" id="activateSearch"><label for="activateSearch">Focus the search box when any key is pressed</label></div>
     <div><input type="checkbox" id="autoselectFirst"><label for="autoselectFirst">Automatically select the first search result <em>(experimental)</em></label></div>
     <div><input type="checkbox" id="addSpaceOnFocus"><label for="addSpaceOnFocus">Add a space when focusing the search box</label></div>
+    <div><input type="checkbox" id="enableGoogleShortcuts"><label for="enableGoogleShortcuts">Enable Google special shortcuts: [A]ll, [I]mages, [V]ideo, [M]aps</label></div>
   </div>
   <br /><br />
   <div id="actionContainer">


### PR DESCRIPTION
Hi, thanks for creating this plugin!
I’ve added keyboard shortcuts to quickly access some common Google search tabs. Specifically, I mapped `A` to "All", `I` to "Images", `V` to "Videos and `M` to "Maps".
These shortcuts are optional and disabled by default, so the plugin's current behavior remains unchanged unless enabled.

I noticed there was a previous issue regarding this feature [here](https://github.com/jchafik/google-search-shortcuts/issues/10), so I thought this might be a useful addition. I haven’t tested it on Firefox, so you might want to check compatibility!